### PR TITLE
当前临时文件命名的方式为数字后面加1,这样当项目较大,jar较多的时候,会出现覆盖同名jar包的现象,比如要inject的包为3.jar,…

### DIFF
--- a/auto-inject-plugin/src/main/groovy/com/eastwood/tools/plugins/autoinject/AutoInjector.groovy
+++ b/auto-inject-plugin/src/main/groovy/com/eastwood/tools/plugins/autoinject/AutoInjector.groovy
@@ -92,7 +92,7 @@ class AutoInjector {
             }
 
             if (tempModifiedClassByteMap.size() != 0) {
-                File tempJar = new File(source.absolutePath.replace('.jar', '1.jar'))
+                File tempJar = new File(source.absolutePath.replace('.jar', 'temp.jar'))
                 if (tempJar.exists())
                     tempJar.delete()
 


### PR DESCRIPTION
…temp文件为31.jar,项目本身的31.jar就会被覆盖而在编译的时候报错找不到31.jar,因此修改为3temp.jar以避免覆盖